### PR TITLE
Fix stale mapping collisions corrupting deobfuscation

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -37,6 +37,11 @@ export class MemoryStore implements MappingStore {
   put(real: string, fake: string, category: Category): void {
     // If already present, update in place (no eviction needed)
     if (this._realToFake.has(real)) {
+      const oldFake = this._realToFake.get(real)!;
+      if (oldFake !== fake) {
+        // Real value remapped to a new fake — clean up the old fake's reverse entry
+        this._fakeToReal.delete(oldFake);
+      }
       this._realToFake.set(real, fake);
       this._fakeToReal.set(fake, real);
       this._categories.set(real, category);
@@ -55,15 +60,17 @@ export class MemoryStore implements MappingStore {
     }
 
     // Detect collision: if this fake is already mapped to a DIFFERENT real value,
-    // the reverse lookup would be corrupted. Log a warning but still store —
-    // the forward lookup (real→fake) is correct; only deobfuscation may be
-    // impacted for the earlier value that shared this fake.
+    // the old real value's forward mapping becomes orphaned — it points to a fake
+    // that now reverse-maps to a different real value.  This corrupts deobfuscation:
+    // the orphaned fake will be replaced with the WRONG real value.
+    // Fix: evict the old real value entirely so the store stays bidirectionally consistent.
     const existingReal = this._fakeToReal.get(fake);
     if (existingReal !== undefined && existingReal !== real) {
-      // Collision: two real values map to the same fake.
-      // Keep both forward mappings but the reverse will point to the newer one.
-      // This is a known limitation of subnet-preserving IP mapping when
-      // many subnets are allocated in the limited CGNAT /10 space.
+      // Collision: evict the old real value to prevent orphaned mappings
+      this._realToFake.delete(existingReal);
+      this._categories.delete(existingReal);
+      const idx = this._insertionOrder.indexOf(existingReal);
+      if (idx !== -1) this._insertionOrder.splice(idx, 1);
     }
 
     this._realToFake.set(real, fake);

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -106,3 +106,46 @@ describe("LRU eviction (QW10)", () => {
     expect(store.size()).toBe(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Collision handling: two real values mapped to the same fake
+// ---------------------------------------------------------------------------
+
+describe("collision eviction", () => {
+  test("collision evicts the old real value to keep store consistent", () => {
+    const store = new MemoryStore();
+    store.put("Morgan", "PREVIEW", Category.PERSON_NAME);
+    store.put("Freeman", "PREVIEW", Category.PERSON_NAME);
+    // "Morgan" should have been evicted — its fake was reassigned
+    expect(store.getFake("Morgan")).toBeUndefined();
+    expect(store.getCategory("Morgan")).toBeUndefined();
+    // "Freeman" owns the fake now
+    expect(store.getFake("Freeman")).toBe("PREVIEW");
+    expect(store.getReal("PREVIEW")).toBe("Freeman");
+    expect(store.size()).toBe(1);
+  });
+
+  test("update-in-place cleans up old fake reverse entry", () => {
+    const store = new MemoryStore();
+    store.put("alice@test.com", "fake1@test.com", Category.EMAIL);
+    expect(store.getReal("fake1@test.com")).toBe("alice@test.com");
+    // Remap alice to a different fake
+    store.put("alice@test.com", "fake2@test.com", Category.EMAIL);
+    expect(store.getFake("alice@test.com")).toBe("fake2@test.com");
+    expect(store.getReal("fake2@test.com")).toBe("alice@test.com");
+    // Old fake should no longer reverse-map
+    expect(store.getReal("fake1@test.com")).toBeUndefined();
+    expect(store.size()).toBe(1);
+  });
+
+  test("allMappings excludes evicted collision entries", () => {
+    const store = new MemoryStore();
+    store.put("real1", "samefake", Category.EMAIL);
+    store.put("real2", "samefake", Category.PHONE);
+    const mappings = store.allMappings();
+    // Only real2 should remain — real1 was evicted by collision
+    expect(mappings.size).toBe(1);
+    expect(mappings.get("real2")).toBe("samefake");
+    expect(mappings.has("real1")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- When two real values mapped to the same fake (collision), the old real value's forward mapping was left orphaned in `_realToFake`
- During deobfuscation, the orphaned fake would be replaced with the **wrong** real value
- After ~1,887 accumulated mappings across sessions, this caused text corruption — e.g., "Morgan" → "PREVIEW\n"

## Changes

**`src/store.ts`:**
- `put()` collision path: evict the old real value entirely when its fake is reassigned to a new real value (delete from `_realToFake`, `_categories`, and `_insertionOrder`)
- `put()` update-in-place path: clean up the old fake's reverse entry when a real value is remapped to a new fake

**`tests/store.test.ts`:**
- 3 new tests: collision eviction, update-in-place cleanup, allMappings consistency after collision

## Reproducer

After many sessions sharing a single Shroud instance (e.g., research-agent gateway running for hours with multiple agents), the mapping store accumulates thousands of entries. Fake value collisions create orphaned forward mappings. Calling `deobfuscate()` on text containing common words like "Morgan" would replace them with unrelated fake values from previous sessions — corrupting file writes and reports.

## Test plan

- [x] All 13 store tests pass (10 existing + 3 new)
- [ ] Run full test suite
- [ ] Deploy to research-agent gateway, run `/earnings TXN` and verify no text corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)