### PR TITLE
[codex] fix credential detection coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc",
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "vitest run",
+    "test:unit": "npm run build && vitest run",
     "test:integration": "node tests/harness/run.mjs",
     "test:docker": "bash compat/run-e2e.sh latest",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:docker",

--- a/src/detectors/regex.ts
+++ b/src/detectors/regex.ts
@@ -290,7 +290,7 @@ export const BUILTIN_PATTERNS: PatternDef[] = [
   },
   {
     name: "api_key_test_placeholder",
-    pattern: /\bSHROUD_TEST_(?:API|OPENAI|ANTHROPIC|AWS_ACCESS|GOOGLE_API|GITHUB|SLACK|SLACK_APP|STRIPE)_(?:KEY|TOKEN)\b/g,
+    pattern: /\bSHROUD_TEST_(?:API|OPENAI|ANTHROPIC|AWS_ACCESS|AWS_SECRET|GOOGLE_API|GITHUB|SLACK|SLACK_APP|STRIPE|SENDGRID)_(?:KEY|TOKEN)\b/g,
     category: Category.API_KEY,
     confidence: 0.95,
   },
@@ -697,6 +697,12 @@ export const BUILTIN_PATTERNS: PatternDef[] = [
     confidence: 0.95,
   },
   {
+    name: "jwt_test_placeholder",
+    pattern: /\bSHROUD_TEST_JWT\b/g,
+    category: Category.JWT,
+    confidence: 0.95,
+  },
+  {
     name: "oauth_refresh_token",
     pattern: /(?:refresh_token["':\s]+)([A-Za-z0-9\-_]{20,})/g,
     category: Category.API_KEY,
@@ -777,6 +783,12 @@ export const BUILTIN_PATTERNS: PatternDef[] = [
   {
     name: "pem_private_key",
     pattern: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----/g,
+    category: Category.CERTIFICATE,
+    confidence: 1.00,
+  },
+  {
+    name: "pem_key_block",
+    pattern: /-----BEGIN [A-Z ]*KEY-----[\s\S]*?-----END [A-Z ]*KEY-----/g,
     category: Category.CERTIFICATE,
     confidence: 1.00,
   },
@@ -1076,7 +1088,7 @@ export const BUILTIN_PATTERNS: PatternDef[] = [
     // DB_PASSWORD=SHROUD_TEST_PASSWORD
     // Excludes quoted values — those are handled by the attribute_password rule.
     name: "env_var_secret",
-    pattern: /(?:^|[\n;])\s*\w*(?:PASSWORD|PASSWD|SECRET|_KEY|_TOKEN)\w*\s*=\s*(?!"|\s*$)(\S+)/gmi,
+    pattern: /(?:^|[\n;])\s*(?:export\s+)?\w*(?:PASSWORD|PASSWD|SECRET|_KEY|_TOKEN)\w*\s*=\s*(?!"|\s*$)(\S+)/gmi,
     category: Category.NETWORK_CREDENTIAL,
     confidence: 0.95,
   },

--- a/src/generators/codes.ts
+++ b/src/generators/codes.ts
@@ -110,7 +110,7 @@ export class CodeGenerator implements BaseGenerator {
     buf.writeUInt32BE(((seed >>> 16) ^ 0xcafebabe) >>> 0, 4);
     const h = createHash("sha256").update(buf).digest("hex");
 
-    if (original) {
+    if (original && !original.startsWith("SHROUD_TEST_")) {
       // Preserve prefix pattern (e.g., "sk-prod-" -> "sk-test-")
       const prefixMatch = original.match(/^([a-zA-Z]+[-_](?:[a-zA-Z]+[-_])?)/);
       if (prefixMatch) {

--- a/tests/generators.test.ts
+++ b/tests/generators.test.ts
@@ -123,7 +123,7 @@ describe("API key generation", () => {
   test("starts with prefix like sk-shroud- when original has sk- prefix", () => {
     const engine = new MappingEngine("test-secret", "fixed-salt");
     const fake = engine.mapValue(
-      "SHROUD_TEST_API_KEY",
+      "sk-real-abc123def456ghi789jkl012mno345",
       Category.API_KEY,
     );
     expect(fake.startsWith("sk-")).toBe(true);

--- a/tests/harness/harness/scenarios/api-keys-tokens.json
+++ b/tests/harness/harness/scenarios/api-keys-tokens.json
@@ -90,8 +90,8 @@
     "name": "JWT three-part token",
     "input": "Token: SHROUD_TEST_JWT",
     "assertions": {
-      "llm_must_not_see": ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"],
-      "user_must_see": ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"],
+      "llm_must_not_see": ["SHROUD_TEST_JWT"],
+      "user_must_see": ["SHROUD_TEST_JWT"],
       "entity_count_min": 1,
       "categories": ["jwt"],
       "roundtrip": true
@@ -101,7 +101,8 @@
     "name": "Bearer token in Authorization header",
     "input": "Authorization: Bearer SHROUD_TEST_JWT",
     "assertions": {
-      "llm_must_not_see": ["eyJhbGciOiJIUzI1NiJ9"],
+      "llm_must_not_see": ["SHROUD_TEST_JWT"],
+      "user_must_see": ["SHROUD_TEST_JWT"],
       "entity_count_min": 1,
       "roundtrip": true
     }

--- a/tests/harness/harness/scenarios/connection-strings.json
+++ b/tests/harness/harness/scenarios/connection-strings.json
@@ -53,8 +53,8 @@
     "name": "URL query param: password",
     "input": "https://app.internal/login?password=SHROUD_TEST_PASSWORD=admin",
     "assertions": {
-      "llm_must_not_see": ["MyS3cretP@ss"],
-      "user_must_see": ["MyS3cretP@ss"],
+      "llm_must_not_see": ["SHROUD_TEST_PASSWORD"],
+      "user_must_see": ["SHROUD_TEST_PASSWORD"],
       "entity_count_min": 1,
       "roundtrip": true
     }
@@ -73,8 +73,8 @@
     "name": "URL query param: token",
     "input": "https://api.internal/auth?token=SHROUD_TEST_TOKEN",
     "assertions": {
-      "llm_must_not_see": ["MyTokenValue12345"],
-      "user_must_see": ["MyTokenValue12345"],
+      "llm_must_not_see": ["SHROUD_TEST_TOKEN"],
+      "user_must_see": ["SHROUD_TEST_TOKEN"],
       "entity_count_min": 1,
       "roundtrip": true
     }

--- a/tests/harness/harness/scenarios/credentials.json
+++ b/tests/harness/harness/scenarios/credentials.json
@@ -64,9 +64,9 @@
       "name": "Environment variables with secrets",
       "input": "# .env.production — DO NOT COMMIT\nDB_PASSWORD=SHROUD_TEST_PASSWORD",
       "assertions": {
-        "llm_must_not_see": ["xK9#mP2$vL5nQ8wR", "SHROUD_TEST_STRIPE_KEY", "xslack-bot-0000000000-FAKETOKEN"],
-        "user_must_see": ["xK9#mP2$vL5nQ8wR", "SHROUD_TEST_STRIPE_KEY"],
-        "entity_count_min": 3,
+        "llm_must_not_see": ["SHROUD_TEST_PASSWORD"],
+        "user_must_see": ["SHROUD_TEST_PASSWORD"],
+        "entity_count_min": 1,
         "roundtrip": true
       }
     },
@@ -151,9 +151,9 @@
       "name": "DB_PASSWORD env var format",
       "input": "# Production environment\nDB_HOST=10.50.1.100\nDB_PORT=5432\nDB_PASSWORD=SHROUD_TEST_PASSWORD",
       "assertions": {
-        "llm_must_not_see": ["xK9#mP2$vL5nQ8wR", "R3d1s!Auth#T0k3n", "10.50.1.100"],
-        "user_must_see": ["xK9#mP2$vL5nQ8wR", "R3d1s!Auth#T0k3n", "10.50.1.100"],
-        "entity_count_min": 3,
+        "llm_must_not_see": ["SHROUD_TEST_PASSWORD", "10.50.1.100"],
+        "user_must_see": ["SHROUD_TEST_PASSWORD", "10.50.1.100"],
+        "entity_count_min": 2,
         "no_cgnat_leak": true,
         "roundtrip": true
       }


### PR DESCRIPTION
## What changed

- Build `dist/` before `npm run test:unit`, because several unit tests intentionally exercise compiled consumer output.
- Expand credential detection for sanitized test placeholders, `export NAME=value` environment secrets, JWT placeholders, and generic PEM key blocks.
- Avoid preserving the synthetic `SHROUD_TEST_` prefix when generating fake API keys, while keeping real `sk-`-style prefix preservation covered.
- Align APP harness assertions with the sanitized placeholder values currently present in the scenario inputs.

## Why

A fresh checkout exposed unit-test failures when `dist/` did not exist. The full APP harness then found credential coverage gaps where exported AWS secrets and PEM-like key blocks could pass through, plus stale scenario assertions that referenced old real-secret fixture values no longer present in the inputs.

## Validation

- `npm run lint`
- `npm run test:unit` (993 passed)
- `npm run test:integration` (359 passed)